### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,4 +1,6 @@
 name: CICD
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Significant-Gravitas/gravitasml/security/code-scanning/1](https://github.com/Significant-Gravitas/gravitasml/security/code-scanning/1)

To fix the problem, we should add an explicit `permissions` block to the workflow or to each job that does not already have one. The minimal required permission for most CI jobs (such as `build`, `lint`, and `test`) is `contents: read`, unless they need to write to the repository or perform other privileged actions (which they do not in this case). The `publish` job already has a tailored `permissions` block, so no changes are needed there. The best way to fix this is to add a `permissions: contents: read` block at the top level of the workflow (just after the `name:` and before `on:`), which will apply to all jobs except those that override it (like `publish`). This approach is concise and future-proof.

**What to change:**  
- Insert the following at line 2, after `name: CICD` and before `on:`:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes are needed, as the `publish` job already has its own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
